### PR TITLE
Set steempress homepage to empty

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -87,7 +87,7 @@
   },
   "steempress": {
     "name": "SteemPress",
-    "homepage": "https://wordpress.org/plugins/steempress/"
+    "homepage": ""
   },
   "strimi": {
     "name": "Strimi",


### PR DESCRIPTION
Hello, 

Great PR here : https://github.com/steemit/condenser/pull/2995 ! It's a much needed change and your implementation is great. The issue that I have is that SteemPress isn't a dapp with one website, 

It's thousands of blogs with various different urls. After debating a bit we realized that if we allowed any blogs to set any canonical link it would quickly result in abuse and hurt steemit.com's SEO (or any other site running condenser). But setting self referencing canonical links is still hurting those blogs, so first of all I propose to set the canonical link to empty in the case of steempress to reduce the damage. I'm not 100% sure that just setting the canonical link to empty works though, what do you think ? 

And in the future I am convinced I can create a whitelist of trusted blogs (each one would be its onwn dapp basically), Would you be open to have something like this in the future ?