### PR TITLE
Append Actifit dapp to the list

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -116,5 +116,9 @@
     "name": "Hede.io",
     "homepage": "https://hede.io",
     "url_scheme": "https://hede.io/hede-io/@{username}/{permlink}"
+  },
+  "actifit": {
+    "name": "Actifit",
+    "homepage": "https://actifit.io"
   }
 }


### PR DESCRIPTION
Adding Actifit dapp to the list. 
In the near future we will also have a post  structure as we make Actifit posts available under actifit.io as fully linkable urls, for now we do not, hence we did not include a url_scheme yet.
Thanks